### PR TITLE
Potential fix for code scanning alert no. 79: Type confusion through parameter tampering

### DIFF
--- a/routes/search.ts
+++ b/routes/search.ts
@@ -19,6 +19,11 @@ class ErrorWithParent extends Error {
 export function searchProducts () {
   return (req: Request, res: Response, next: NextFunction) => {
     let criteria: any = req.query.q === 'undefined' ? '' : req.query.q ?? ''
+    if (typeof criteria !== 'string') {
+      // Reject if criteria is not a string (e.g., array or object)
+      res.status(400).json({ error: 'Invalid query parameter' })
+      return
+    }
     criteria = (criteria.length <= 200) ? criteria : criteria.substring(0, 200)
     models.sequelize.query(`SELECT * FROM Products WHERE ((name LIKE '%${criteria}%' OR description LIKE '%${criteria}%') AND deletedAt IS NULL) ORDER BY name`) // vuln-code-snippet vuln-line unionSqlInjectionChallenge dbSchemaChallenge
       .then(([products]: any) => {


### PR DESCRIPTION
Potential fix for [https://github.com/luiscarlos3001/juice-shop-dsa-ada-aluno/security/code-scanning/79](https://github.com/luiscarlos3001/juice-shop-dsa-ada-aluno/security/code-scanning/79)

To fix the problem, we need to ensure that `criteria` is always a string before using string methods or interpolating it into the SQL query. The best way is to check the type of `req.query.q` and handle arrays and other types safely. If `req.query.q` is an array, we can either reject the request as invalid or join the array elements into a single string (e.g., with commas), depending on the desired behavior. For security, it's safest to only accept strings and reject arrays or other types. The fix should be applied in the region where `criteria` is assigned and sanitized (lines 21-22). No new methods or imports are needed; just a type check and appropriate handling.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
