### PR TITLE
Potential fix for code scanning alert no. 78: Type confusion through parameter tampering

### DIFF
--- a/lib/insecurity.ts
+++ b/lib/insecurity.ts
@@ -133,6 +133,9 @@ export const redirectAllowlist = new Set([
 ])
 
 export const isRedirectAllowed = (url: string) => {
+  if (typeof url !== 'string') {
+    return false
+  }
   let allowed = false
   for (const allowedUrl of redirectAllowlist) {
     allowed = allowed || url.includes(allowedUrl) // vuln-code-snippet vuln-line redirectChallenge

--- a/routes/redirect.ts
+++ b/routes/redirect.ts
@@ -12,7 +12,11 @@ import * as utils from '../lib/utils'
 
 export function performRedirect () {
   return ({ query }: Request, res: Response, next: NextFunction) => {
-    const toUrl: string = query.to as string
+    const toUrl = query.to
+    if (typeof toUrl !== 'string') {
+      res.status(400).send('Invalid redirect URL')
+      return
+    }
     if (security.isRedirectAllowed(toUrl)) {
       challengeUtils.solveIf(challenges.redirectCryptoCurrencyChallenge, () => { return toUrl === 'https://explorer.dash.org/address/Xr556RzuwX6hg5EGpkybbv5RanJoZN17kW' || toUrl === 'https://blockchain.info/address/1AbKfgvw9psQ41NbLi8kufDQTezwG8DRZm' || toUrl === 'https://etherscan.io/address/0x0f933ab9fcaaa782d0279c300d73750e1311eae6' })
       challengeUtils.solveIf(challenges.redirectChallenge, () => { return isUnintendedRedirect(toUrl) })


### PR DESCRIPTION
Potential fix for [https://github.com/luiscarlos3001/juice-shop-dsa-ada-aluno/security/code-scanning/78](https://github.com/luiscarlos3001/juice-shop-dsa-ada-aluno/security/code-scanning/78)

To fix the issue, we need to ensure that the `query.to` parameter is validated to be a string before it is used. This can be achieved by adding a type check in the `performRedirect` function in `routes/redirect.ts`. If `query.to` is not a string, the function should reject the request with an appropriate error message.

Additionally, the `isRedirectAllowed` function in `lib/insecurity.ts` should also validate the type of its `url` parameter to ensure robustness, even if the primary validation is done earlier.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
